### PR TITLE
Handle state evolution without breaking state compatibility

### DIFF
--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MapSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MapSerializer.scala
@@ -2,8 +2,7 @@ package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
-import org.apache.flink.util.InstantiationUtil
-import org.apache.flinkx.api.serializer.MapSerializer._
+import org.apache.flinkx.api.serializer.MapSerializer.*
 
 class MapSerializer[K, V](ks: TypeSerializer[K], vs: TypeSerializer[V]) extends SimpleSerializer[Map[K, V]] {
   override def createInstance(): Map[K, V] = Map.empty[K, V]
@@ -32,33 +31,23 @@ class MapSerializer[K, V](ks: TypeSerializer[K], vs: TypeSerializer[V]) extends 
 object MapSerializer {
   case class MapSerializerSnapshot[K, V](var keySerializer: TypeSerializer[K], var valueSerializer: TypeSerializer[V])
       extends TypeSerializerSnapshot[Map[K, V]] {
+
     def this() = this(null, null)
-    override def getCurrentVersion: Int = 1
+
+    override def getCurrentVersion: Int = 2
 
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
-      keySerializer = readSerializer[K](in, userCodeClassLoader)
-      valueSerializer = readSerializer[V](in, userCodeClassLoader)
-    }
-
-    def readSerializer[T](in: DataInputView, userCodeClassLoader: ClassLoader): TypeSerializer[T] = {
-      val snapClass      = InstantiationUtil.resolveClassByName[TypeSerializerSnapshot[T]](in, userCodeClassLoader)
-      val nestedSnapshot = InstantiationUtil.instantiate(snapClass)
-      nestedSnapshot.readSnapshot(nestedSnapshot.getCurrentVersion, in, userCodeClassLoader)
-      nestedSnapshot.restoreSerializer()
+      keySerializer = TypeSerializerSnapshot.readVersionedSnapshot[K](in, userCodeClassLoader).restoreSerializer()
+      valueSerializer = TypeSerializerSnapshot.readVersionedSnapshot[V](in, userCodeClassLoader).restoreSerializer()
     }
 
     override def writeSnapshot(out: DataOutputView): Unit = {
-      writeSerializer[K](keySerializer, out)
-      writeSerializer[V](valueSerializer, out)
-    }
-
-    def writeSerializer[T](nestedSerializer: TypeSerializer[T], out: DataOutputView) = {
-      out.writeUTF(nestedSerializer.snapshotConfiguration().getClass.getName)
-      nestedSerializer.snapshotConfiguration().writeSnapshot(out)
+      TypeSerializerSnapshot.writeVersionedSnapshot(out, keySerializer.snapshotConfiguration())
+      TypeSerializerSnapshot.writeVersionedSnapshot(out, valueSerializer.snapshotConfiguration())
     }
 
     override def resolveSchemaCompatibility(
-        newSerializer: TypeSerializerSnapshot[Map[K, V]]
+        oldSerializerSnapshot: TypeSerializerSnapshot[Map[K, V]]
     ): TypeSerializerSchemaCompatibility[Map[K, V]] = TypeSerializerSchemaCompatibility.compatibleAsIs()
 
     override def restoreSerializer(): TypeSerializer[Map[K, V]] = new MapSerializer(keySerializer, valueSerializer)

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
@@ -1,17 +1,9 @@
 package org.apache.flinkx.api.serializer
 
-import org.apache.flinkx.api.serializer.MappedSerializer.{MappedSerializerSnapshot, TypeMapper}
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.common.typeutils.{
-  CompositeTypeSerializerSnapshot,
-  GenericTypeSerializerSnapshot,
-  SimpleTypeSerializerSnapshot,
-  TypeSerializer,
-  TypeSerializerSchemaCompatibility,
-  TypeSerializerSnapshot
-}
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.util.InstantiationUtil
+import org.apache.flinkx.api.serializer.MappedSerializer.{MappedSerializerSnapshot, TypeMapper}
 
 case class MappedSerializer[A, B](mapper: TypeMapper[A, B], ser: TypeSerializer[B]) extends SimpleSerializer[A] {
   override def equals(obj: Any): Boolean = ser.equals(obj)
@@ -41,34 +33,35 @@ object MappedSerializer {
     def map(a: A): B
     def contramap(b: B): A
   }
-  class MappedSerializerSnapshot[A, B]() extends TypeSerializerSnapshot[A] {
-    var mapper: TypeMapper[A, B] = _
-    var ser: TypeSerializer[B]   = _
-    def this(xmapper: TypeMapper[A, B], xser: TypeSerializer[B]) = {
-      this()
-      mapper = xmapper
-      ser = xser
-    }
+
+  class MappedSerializerSnapshot[A, B](
+      var mapper: TypeMapper[A, B],
+      var ser: TypeSerializer[B]
+  ) extends TypeSerializerSnapshot[A] {
+
+    // Empty constructor is required to instantiate this class during deserialization.
+    def this() = this(null, null)
 
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
       val mapperClazz = InstantiationUtil.resolveClassByName[TypeMapper[A, B]](in, userCodeClassLoader)
       mapper = InstantiationUtil.instantiate(mapperClazz)
       val serClazz = InstantiationUtil.resolveClassByName[TypeSerializer[B]](in, userCodeClassLoader)
-      ser = InstantiationUtil.instantiate(serClazz)
+      ser = TypeSerializerSnapshot.readVersionedSnapshot[B](in, userCodeClassLoader).restoreSerializer()
     }
 
     override def resolveSchemaCompatibility(
-        newSerializer: TypeSerializerSnapshot[A]
+        oldSerializerSnapshot: TypeSerializerSnapshot[A]
     ): TypeSerializerSchemaCompatibility[A] =
       TypeSerializerSchemaCompatibility.compatibleAsIs()
 
     override def writeSnapshot(out: DataOutputView): Unit = {
       out.writeUTF(mapper.getClass.getName)
-      out.writeUTF(ser.getClass.getName)
+      TypeSerializerSnapshot.writeVersionedSnapshot(out, ser.snapshotConfiguration())
     }
 
     override def restoreSerializer(): TypeSerializer[A] = new MappedSerializer[A, B](mapper, ser)
 
-    override def getCurrentVersion: Int = 1
+    override def getCurrentVersion: Int = 2
   }
+
 }

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ScalaCaseObjectSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ScalaCaseObjectSerializer.scala
@@ -1,10 +1,10 @@
 package org.apache.flinkx.api.serializer
 
-import org.apache.flinkx.api.serializer.ScalaCaseObjectSerializer.ScalaCaseObjectSerializerSnapshot
-import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.util.InstantiationUtil
+import org.apache.flinkx.api.serializer.ScalaCaseObjectSerializer.ScalaCaseObjectSerializerSnapshot
 
 class ScalaCaseObjectSerializer[T](clazz: Class[T]) extends TypeSerializerSingleton[T] {
   override def isImmutableType: Boolean                                  = true
@@ -37,7 +37,7 @@ object ScalaCaseObjectSerializer {
 
     override def getCurrentVersion: Int = 1
     override def resolveSchemaCompatibility(
-        newSerializer: TypeSerializerSnapshot[T]
+        oldSerializerSnapshot: TypeSerializerSnapshot[T]
     ): TypeSerializerSchemaCompatibility[T] =
       TypeSerializerSchemaCompatibility.compatibleAsIs()
 

--- a/modules/flink-2-api/src/test/scala/org/apache/flinkx/api/serializer/CollectionSerializerSnapshotTest.scala
+++ b/modules/flink-2-api/src/test/scala/org/apache/flinkx/api/serializer/CollectionSerializerSnapshotTest.scala
@@ -1,0 +1,33 @@
+package org.apache.flinkx.api.serializer
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSnapshot}
+import org.apache.flink.core.memory.{DataInputDeserializer, DataOutputSerializer}
+import org.apache.flinkx.api.serializers.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CollectionSerializerSnapshotTest extends AnyFlatSpec with Matchers {
+
+  it should "serialize then deserialize" in {
+    val serializerConfig = new SerializerConfigImpl()
+    // Create SerializerSnapshot
+    val tSerializer = implicitly[TypeSerializer[String]]
+    val serializerSnapshot: CollectionSerializerSnapshot[Set, String, SetSerializer[String]] =
+      new CollectionSerializerSnapshot(tSerializer, classOf[SetSerializer[String]], classOf[String])
+
+    val expectedSerializer = serializerSnapshot.restoreSerializer()
+
+    // Serialize SerializerSnapshot
+    val snapshotOutput = new DataOutputSerializer(1024 * 1024)
+    TypeSerializerSnapshot.writeVersionedSnapshot(snapshotOutput, serializerSnapshot)
+    val snapshotInput = new DataInputDeserializer(snapshotOutput.getSharedBuffer)
+
+    // Deserialize SerializerSnapshot
+    val deserializedSnapshot = TypeSerializerSnapshot
+      .readVersionedSnapshot[SetSerializer[String]](snapshotInput, getClass.getClassLoader)
+
+    deserializedSnapshot.restoreSerializer() should be(expectedSerializer)
+  }
+
+}

--- a/modules/flink-2-api/src/test/scala/org/apache/flinkx/api/serializer/MapSerializerSnapshotTest.scala
+++ b/modules/flink-2-api/src/test/scala/org/apache/flinkx/api/serializer/MapSerializerSnapshotTest.scala
@@ -1,0 +1,178 @@
+package org.apache.flinkx.api.serializer
+
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
+import org.apache.flink.core.memory.{DataInputDeserializer, DataInputView, DataOutputSerializer, DataOutputView}
+import org.apache.flinkx.api.serializer.MapSerializer.MapSerializerSnapshot
+import org.apache.flinkx.api.serializer.MapSerializerSnapshotTest.*
+import org.apache.flinkx.api.serializers.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MapSerializerSnapshotTest extends AnyFlatSpec with Matchers {
+
+  it should "serialize the old data and deserialize them to the new data" in {
+    // Old data of the type Map[String, OldClass]
+    val oldData = Map("1" -> OldClass(1))
+
+    val keySerializer      = implicitly[TypeSerializer[String]]
+    val oldValueSerializer = new OldOuterTraitSerializer()
+
+    // Create MapSerializerSnapshot
+    val mapSerializerSnapshot: MapSerializerSnapshot[String, OuterTrait] =
+      MapSerializerSnapshot(keySerializer, oldValueSerializer)
+
+    val mapSerializer: TypeSerializer[Map[String, OuterTrait]] = mapSerializerSnapshot.restoreSerializer()
+
+    // Serialize MapSerializerSnapshot
+    val oldOutput = new DataOutputSerializer(1024 * 1024)
+    TypeSerializerSnapshot.writeVersionedSnapshot(oldOutput, mapSerializerSnapshot)
+
+    // Serialize the old data
+    mapSerializer.serialize(oldData, oldOutput)
+
+    // Switch to a new version of the code, now the data are expected to be of the type Map[String, NewClass]
+    MapSerializerSnapshotTest.VersionOfTheCode = 1
+
+    val oldInput = new DataInputDeserializer(oldOutput.getSharedBuffer)
+
+    // Deserialize MapSerializerSnapshot
+    val reconfiguredSnapshot: TypeSerializerSnapshot[Map[String, OuterTrait]] = TypeSerializerSnapshot
+      .readVersionedSnapshot[Map[String, OuterTrait]](oldInput, getClass.getClassLoader)
+    val reconfiguredMapSnapshot = reconfiguredSnapshot.asInstanceOf[MapSerializerSnapshot[String, OuterTrait]]
+    reconfiguredMapSnapshot.valueSerializer should be(a[ReconfiguredOuterTraitSerializer])
+    val reconfiguredSerializer = reconfiguredSnapshot.restoreSerializer()
+
+    // Deserialize the old data but convert them to the new data
+    val reconfiguredData = reconfiguredSerializer.deserialize(oldInput)
+    reconfiguredData should be(Map("1" -> NewClass(1L)))
+
+    // Serialize MapSerializerSnapshot
+    val newOutput = new DataOutputSerializer(1024 * 1024)
+    TypeSerializerSnapshot.writeVersionedSnapshot(newOutput, reconfiguredSnapshot)
+
+    // Serialize the new data
+    reconfiguredSerializer.serialize(reconfiguredData, newOutput)
+
+    val newInput = new DataInputDeserializer(newOutput.getSharedBuffer)
+
+    // Deserialize MapSerializerSnapshot
+    val newSnapshot: TypeSerializerSnapshot[Map[String, OuterTrait]] = TypeSerializerSnapshot
+      .readVersionedSnapshot[Map[String, OuterTrait]](newInput, getClass.getClassLoader)
+    val newMapSnapshot = newSnapshot.asInstanceOf[MapSerializerSnapshot[String, OuterTrait]]
+    newMapSnapshot.valueSerializer should be(a[NewOuterTraitSerializer])
+
+    val newSerializer = newSnapshot.restoreSerializer()
+
+    // Deserialize the new data
+    val newData = newSerializer.deserialize(newInput)
+    newData should be(Map("1" -> NewClass(1L)))
+  }
+
+}
+
+object MapSerializerSnapshotTest {
+
+  var VersionOfTheCode = 0
+
+  sealed trait OuterTrait
+  case class OldClass(a: Int)  extends OuterTrait
+  case class NewClass(a: Long) extends OuterTrait
+
+  class OldOuterTraitSerializer extends SimpleSerializer[OuterTrait] {
+
+    private val intSer = implicitly[TypeSerializer[Int]]
+
+    override def createInstance(): OuterTrait = OldClass(0)
+
+    override def getLength: Int = 4
+
+    override def serialize(record: OuterTrait, target: DataOutputView): Unit = {
+      val oc = record.asInstanceOf[OldClass]
+      intSer.serialize(oc.a, target)
+    }
+
+    override def deserialize(source: DataInputView): OuterTrait = {
+      val a = intSer.deserialize(source)
+      OldClass(a)
+    }
+
+    override def snapshotConfiguration(): TypeSerializerSnapshot[OuterTrait] = new OuterTraitSerializerSnapshot()
+
+  }
+
+  class ReconfiguredOuterTraitSerializer extends SimpleSerializer[OuterTrait] {
+
+    private val intSer  = implicitly[TypeSerializer[Int]]
+    private val longSer = implicitly[TypeSerializer[Long]]
+
+    override def createInstance(): OuterTrait = NewClass(0L)
+
+    override def getLength: Int = -1
+
+    override def serialize(record: OuterTrait, target: DataOutputView): Unit = {
+      val nc = record.asInstanceOf[NewClass]
+      longSer.serialize(nc.a, target)
+    }
+
+    override def deserialize(source: DataInputView): OuterTrait = {
+      val a = intSer.deserialize(source)
+      NewClass(a.toLong)
+    }
+
+    override def snapshotConfiguration(): TypeSerializerSnapshot[OuterTrait] = new OuterTraitSerializerSnapshot()
+
+  }
+
+  class NewOuterTraitSerializer extends SimpleSerializer[OuterTrait] {
+
+    private val longSer = implicitly[TypeSerializer[Long]]
+
+    override def createInstance(): OuterTrait = NewClass(0L)
+
+    override def getLength: Int = 8
+
+    override def serialize(record: OuterTrait, target: DataOutputView): Unit = {
+      val nc = record.asInstanceOf[NewClass]
+      longSer.serialize(nc.a, target)
+    }
+
+    override def deserialize(source: DataInputView): OuterTrait = {
+      val a = longSer.deserialize(source)
+      NewClass(a)
+    }
+
+    override def snapshotConfiguration(): TypeSerializerSnapshot[OuterTrait] = new OuterTraitSerializerSnapshot()
+
+  }
+
+  class OuterTraitSerializerSnapshot extends TypeSerializerSnapshot[OuterTrait] {
+
+    private var ser: TypeSerializer[OuterTrait] = new OldOuterTraitSerializer()
+
+    override def getCurrentVersion: Int = VersionOfTheCode
+
+    override def writeSnapshot(out: DataOutputView): Unit = {}
+
+    override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
+      if (readVersion == 0) {
+        ser = new ReconfiguredOuterTraitSerializer()
+      } else {
+        ser = new NewOuterTraitSerializer()
+      }
+    }
+
+    override def restoreSerializer(): TypeSerializer[OuterTrait] = ser
+
+    override def resolveSchemaCompatibility(
+        oldSerializerSnapshot: TypeSerializerSnapshot[OuterTrait]
+    ): TypeSerializerSchemaCompatibility[OuterTrait] = {
+      if (oldSerializerSnapshot.getCurrentVersion == 0) {
+        TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(new ReconfiguredOuterTraitSerializer())
+      } else {
+        TypeSerializerSchemaCompatibility.compatibleAsIs()
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Hi @novakov-alexey,

As designed in the issue https://github.com/flink-extended/flink-scala-api/issues/240, here is my proposal to handle state evolution without breaking state compatibility.

`ScalaCaseObjectSerializer` has not the issue because it doesn't serialize serializers, but I added `MapSerializer` in addition of the previous list.

Write a test that reproduces the issue and shows this PR fixes it was hard, please have a look at `MapSerializerSnapshotTest`. I didn't write a test for each serializer snapshot, but the logic is the same.

I was surprised to see no tests for Flink 2, I created the root test folder, but maybe tests for Flink 1 should be duplicated for Flink 2 also?

As said in the issue, I can also do these changes for Flink 1, but it will break the state compatibility.